### PR TITLE
v0.1.2 — PR-first ADR process + decisions/README.md index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,19 @@ Thanks for reading the construct closely enough to want to contribute. A few not
 
 OSA distinguishes between **construct changes** and **content changes**, because they have different reversibility profiles.
 
-**Construct changes** modify the framework itself — adding a layer, removing a layer, redefining a layer's authority boundary, changing the governance principle, altering the relationship between OSA and an external framework. These changes are hard to retract once cited. They flow through ADRs:
+**Construct changes** modify the framework itself — adding a layer, removing a layer, redefining a layer's authority boundary, changing the governance principle, altering the relationship between OSA and an external framework. These changes are hard to retract once cited. They flow through ADRs as **PRs**:
 
-1. Open an issue tagged `construct-change` describing the motivation and proposed change.
-2. Draft an ADR in `decisions/ADR-OSA-NNNN-<slug>.md` (numbering is sequential, append-only).
-3. Open a PR with the ADR. Discussion happens on the PR.
-4. Ratification requires explicit sign-off from the maintainer (currently @jdlongmire) and a comment-out period of at least one calendar week unless the change is purely editorial.
+1. *(Optional)* If the change is contentious or you want community signal first, open a **Construct Q&A** discussion describing the question before authoring the ADR.
+2. Draft an ADR in `decisions/ADR-OSA-NNNN-<slug>.md` (numbering is sequential, append-only) using [`decisions/TEMPLATE.md`](decisions/TEMPLATE.md) as a starting point.
+3. Open a PR with the ADR. Apply the **`adr`** label. Discussion happens on the PR — the PR is the deliberation record, the merge is ratification.
+4. Ratification requires explicit sign-off from the maintainer (currently @jdlongmire) and a comment-out period of at least one calendar week, unless the ADR is purely editorial or part of a maintainer-batched founding set.
 5. Merged ADRs are immutable. A later ADR may supersede an earlier one; the earlier one stays in the tree marked `Superseded by ADR-OSA-NNNN`.
+
+See [`decisions/README.md`](decisions/README.md) for the navigable index of ratified ADRs.
+
+### Why PRs (not Issues) for ADRs
+
+The PR *is* the ADR's lifecycle. Discussion on the PR is the deliberation, reviews are the consensus signal, the merge commit is the ratification timestamp, and the file at `decisions/ADR-OSA-NNNN-<slug>.md` is the durable record. Issues are reserved for **construct gaps**, **implementation work**, and **umbrella tracking of multi-ADR programs** — not for the decisions themselves.
 
 **Content changes** — clarifying wording in layer files, adding examples, fixing typos, expanding the framework-positioning doc, improving diagrams — flow as ordinary PRs. No ADR needed.
 
@@ -40,4 +46,12 @@ OSA distinguishes between **construct changes** and **content changes**, because
 - It is **not** a model-evaluation framework. OSA assumes models are capable; it governs whether they're authorized.
 - It is **not** a wrapper around any single vendor's stack. The construct is vendor-neutral by design.
 
-If you have a question about whether your idea fits, open an issue before writing the PR. Cheaper than a rewrite.
+If you have a question about whether your idea fits, open a **Construct Q&A** discussion before writing the PR. Cheaper than a rewrite.
+
+## Artifact roles at a glance
+
+| Artifact | Use for |
+|---|---|
+| **PR** | Concrete changes (content edits, ADRs, schema updates, examples). The PR is the change's lifecycle and record. |
+| **Issue** | Construct gaps, implementation work, umbrella tracking of multi-PR programs. Not the place where decisions get made. |
+| **Discussion** | Pre-PR brainstorming, Construct Q&A, Adoption Stories, Reference Implementation proposals. Output may inform a PR but isn't itself a durable record. |

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -1,0 +1,24 @@
+# Architectural Decision Records
+
+This directory holds the **ratified ADRs** for OSA — append-only records of construct-level decisions and the reasoning behind them.
+
+For the authoring process, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For the ADR shape, see [`TEMPLATE.md`](TEMPLATE.md).
+
+## Index
+
+| ADR | Status | Date | Title |
+|---|---|---|---|
+| _none yet_ | — | — | The founding ADRs (0001–0004) will land with the v0.2 schema PR. |
+
+## Conventions
+
+- **Numbering** is sequential and never reused: `ADR-OSA-0001`, `ADR-OSA-0002`, etc. A retracted-before-merge draft does not consume a number; ADRs are numbered at PR-open time and the number is held until merge or withdrawal.
+- **Filename** is `ADR-OSA-NNNN-<slug>.md` where `<slug>` is lowercase-kebab-case (e.g., `ADR-OSA-0001-schema-first-canonical-form.md`).
+- **Status** values: `Proposed` (PR open), `Accepted` (PR merged), `Superseded by ADR-OSA-NNNN` (a later ADR replaces this one). Withdrawn drafts don't enter the index.
+- **Immutability**: once an ADR is merged, the file is not edited except for typo fixes and the addition of a `Superseded by` note in the header. Substantive revision happens by writing a new ADR that supersedes the old one.
+
+## How to read this index
+
+The entries here are durable claims. If you're integrating OSA into your enterprise architecture practice, ADRs explain the *why* behind the construct as it stands today — they tell you which design alternatives were considered and rejected, so you can judge whether your context warrants reopening a question.
+
+If an entry says **Superseded by**, follow the chain — the latest ADR in the chain is the active position. Earlier ADRs in the chain remain in the tree as history, but should not be cited as current.


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — switches ADR process from issue-first to PR-first; adds optional pre-PR Construct Q&A discussion; requires \`adr\` label on ADR PRs; clarifies PR/Issue/Discussion role separation.
- **decisions/README.md** — new navigable ADR index with conventions for numbering, status, filenames, immutability, and supersession.

## Why

The previous text said "open an issue first, then a PR" — duplicates deliberation across two surfaces. PR-first matches established methodology: the PR is the deliberation record, the merge commit is the ratification timestamp, the merged file is the durable artifact. Issues are reserved for construct gaps, implementation work, and umbrella tracking.

## What's NOT in this PR

- The four founding ADRs (0001 schema-first, 0002 YAML+JSON Schema, 0003 construct-vs-deployment, 0004 Python+pydantic) will land bundled with the v0.2 schema PR. This PR sets up the index they'll populate.

## Repo-side change (out of band, already applied)

- Created the \`adr\` label on this repo (color #5319e7) for filtering ADR PRs.

## QA

Pass with zero warnings (qa_log entry \`2026-05-16T14:51:05Z\`).

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] Internal links resolve (CONTRIBUTING → decisions/README, decisions/README → CONTRIBUTING, both → TEMPLATE)
- [x] No remaining references to "open an issue first" in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)