### PR TITLE
v0.1.3 — founding ADRs 0001-0005 ratify the v0.2 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,28 @@ See [`docs/relationship-to-frameworks.md`](docs/relationship-to-frameworks.md) f
 - **[`docs/layers/`](docs/layers/)** — one file per ordinal layer (O0 through O6)
 - **[`docs/relationship-to-frameworks.md`](docs/relationship-to-frameworks.md)** — OSA next to TOGAF, UAF, ArchiMate, NIST AI RMF
 - **[`docs/reference-implementations.md`](docs/reference-implementations.md)** — concrete implementations of OSA layers (forward placeholder; entries land as they mature)
+- **[`decisions/README.md`](decisions/README.md)** — Architectural Decision Records (ADR index)
 
 ## Status
 
-**v0.1** — Construct definition published. Layer files are scaffolds, intentionally brief; deep-dives, ArchiMate/UAF mappings, and worked examples will follow in v0.2.
+**v0.1.x — construct stable, v0.2 in motion.**
+
+- v0.1 (2026-05-16): construct definition published as Markdown prose (seven layer files, framework positioning, governance principle).
+- v0.1.1: repositioned as unaffiliated research; Ologos-specific framing removed.
+- v0.1.2: PR-first ADR process formalized; `decisions/` directory and ADR index added.
+- v0.2 (in progress): founding ADRs 0001–0005 ratify the schema-first canonical form, YAML + JSON Schema representation, construct vs deployment schema shapes, Python + pydantic reference tooling, and ArchiMate-via-pyArchimate visual rendering pipeline. Schema sketch and reference tooling land next.
+
+Layer files remain intentionally brief; deep-dives, ArchiMate stereotype set, UAF mapping appendix, and worked examples follow in v0.2 and v0.3.
+
+## Governance
+
+OSA's construct-level decisions are captured as [Architectural Decision Records](decisions/README.md) — append-only records of what was decided, the alternatives considered, and the consequences accepted. The five **founding ADRs** establish the v0.2 baseline: schema-first canonical form ([0001](decisions/ADR-OSA-0001-schema-first-canonical-form.md)), YAML + JSON Schema ([0002](decisions/ADR-OSA-0002-schema-language-yaml-json-schema.md)), construct vs deployment schemas ([0003](decisions/ADR-OSA-0003-construct-vs-deployment-schemas.md)), Python + pydantic tooling ([0004](decisions/ADR-OSA-0004-reference-tooling-python-pydantic.md)), and ArchiMate via pyArchimate ([0005](decisions/ADR-OSA-0005-archi-as-canonical-modeling-tool.md)).
+
+Future construct changes flow as ADR PRs per the process in [`CONTRIBUTING.md`](CONTRIBUTING.md). See [`decisions/README.md`](decisions/README.md) for the full index and conventions.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Substantive changes to the construct (new layers, layer redefinition, governance principle revision) go through ADRs; refinements and examples flow as ordinary PRs.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Substantive changes to the construct (new layers, layer redefinition, governance principle revision) go through **ADRs as PRs** (label `adr`); refinements and examples flow as ordinary PRs. Pre-PR brainstorming happens in [GitHub Discussions](https://github.com/osa-ai-org/osa-ai/discussions) under the Construct Q&A category.
 
 ## License
 

--- a/decisions/ADR-OSA-0001-schema-first-canonical-form.md
+++ b/decisions/ADR-OSA-0001-schema-first-canonical-form.md
@@ -1,0 +1,51 @@
+# ADR-OSA-0001 — Schema-first canonical form
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Author:** JD Longmire
+- **Bundle:** Founding ADR (0001 of 0005)
+
+## Context
+
+OSA's construct could be authored canonically in any of several formats: an ArchiMate model, SysML v2 textual source, UAF viewpoints, a custom textual DSL, or a tool-neutral structured schema. The choice is load-bearing because it determines (a) what artifact adopters cite, (b) what artifact gates conformance, and (c) which tool ecosystem OSA implicitly endorses.
+
+v0.1 shipped the construct as Markdown prose only. That works for human reading but offers no mechanical conformance check, no machine-readable layer definitions, and no portable artifact that downstream tools can consume.
+
+OSA's stated posture is **vendor-neutral**: complementary to TOGAF, UAF, ArchiMate, and NIST AI RMF rather than bound to any of them. Authoring the canonical form in any single tool's native notation would silently violate that posture.
+
+## Decision
+
+**The canonical OSA source is a versioned, tool-neutral structured schema.** All other representations — ArchiMate templates, SysML v2 source, UAF viewpoint mappings, ASCII layer diagrams, narrative prose — are **renderings** derived from or consistent with the canonical schema, never the source.
+
+The schema is the artifact adopters cite, validate against, and pin to a release version. Renderings may diverge from the canonical without compromising it; the canonical is what conformance is measured against.
+
+Specific schema format and shape are decided in [ADR-OSA-0002](ADR-OSA-0002-schema-language-yaml-json-schema.md) and [ADR-OSA-0003](ADR-OSA-0003-construct-vs-deployment-schemas.md).
+
+## Consequences
+
+- **Schema expressiveness becomes load-bearing.** The schema must encode all OSA semantics: the seven layers, authority direction, evidence direction, the five execution rights, the conformance assertion structure, allowed cross-layer relationships. A semantic that cannot be expressed in the schema cannot be enforced in conformance checking.
+- **Renderings are downstream artifacts**, not sources. ArchiMate templates, SysML v2 source, UAF mappings — all generated from or audited against the canonical schema.
+- **URL stability matters more than it did in v0.1.** Adopters will cite specific schema versions; releases must pin canonical URLs.
+- **The schema becomes the surface ADRs operate on.** Future construct ADRs change schema fields, allowed values, or relationship rules — not prose paragraphs.
+- **Prose docs (`docs/concept.md`, `docs/layers/O*.md`) become explanatory companion artifacts**, not the source of truth. When prose and schema disagree, schema wins; prose is updated to match.
+- **Validation tooling becomes a v0.2 deliverable**, since conformance against the schema requires it. See [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md).
+
+## Alternatives considered
+
+1. **ArchiMate model as canonical.** Tool-bound; locks adopters into the Open Group / Archi ecosystem. ArchiMate has no MOF representation, so converting to UAF/SysML v2 is hand-built per case. Rejected — violates vendor-neutrality.
+
+2. **SysML v2 textual as canonical.** OMG-bound; locks adopters into MBSE tooling. Strong typing and good ecosystem fit for engineering audiences, but excludes the EA/TOGAF audience and the policy-governance audience (NIST AI RMF). Rejected for the same vendor-neutrality reason.
+
+3. **Multiple equivalent canonical formats with bidirectional sync.** Each adopter community gets its preferred format; tooling keeps them in sync. Rejected — drift is inevitable, and there is no source of truth when two formats disagree.
+
+4. **No canonical artifact (prose only).** What v0.1 shipped. Doesn't scale to adopters who need machine-readable conformance checking. Rejected.
+
+5. **JSON Schema as the canonical authoring format directly.** Bypasses the YAML+JSON-Schema split decided in ADR-OSA-0002. Rejected because JSON Schema is verbose for humans to author and loses comments — a worse source-of-truth UX than YAML.
+
+## References
+
+- [ADR-OSA-0002](ADR-OSA-0002-schema-language-yaml-json-schema.md) — concrete schema language choice
+- [ADR-OSA-0003](ADR-OSA-0003-construct-vs-deployment-schemas.md) — construct vs deployment schema shapes
+- [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md) — reference validator/generator tooling
+- [`../docs/relationship-to-frameworks.md`](../docs/relationship-to-frameworks.md) — OSA's positioning relative to TOGAF, UAF, ArchiMate, NIST AI RMF
+- [`../docs/reference-implementations.md`](../docs/reference-implementations.md) — conformance bar that the schema mechanizes

--- a/decisions/ADR-OSA-0002-schema-language-yaml-json-schema.md
+++ b/decisions/ADR-OSA-0002-schema-language-yaml-json-schema.md
@@ -1,0 +1,54 @@
+# ADR-OSA-0002 — Schema language: YAML source + auto-emitted JSON Schema
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Author:** JD Longmire
+- **Bundle:** Founding ADR (0002 of 0005)
+
+## Context
+
+[ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md) establishes that the canonical OSA source is a versioned, tool-neutral schema. This ADR picks the concrete language.
+
+Candidates evaluated: **YAML**, **JSON Schema**, **TOML**, **Protobuf**, **XML Schema (XSD)**, **custom DSL**. Constraints: human-readable for authoring, machine-validatable across language ecosystems, broad familiarity in EA and research communities, no proprietary tooling required.
+
+A secondary constraint: adopters need a machine-validatable artifact (something a deployment can be checked against), not just a human-readable one. The two needs are in tension — human-friendly formats like YAML lack the strict typing of JSON Schema, while strict-typed formats like Protobuf are harder for humans to author and read.
+
+## Decision
+
+**The canonical OSA schema is authored in YAML.** A JSON Schema representation is **auto-emitted** from the YAML source for tooling consumption (validators, IDE integrations, code generators).
+
+- **YAML** (`osa-N.M.yaml`) is the source of truth. Edited by hand, reviewed in PRs, the artifact ADRs touch.
+- **JSON Schema** (`osa-N.M.schema.json`) is a derived artifact, generated from the YAML by reference tooling at release time. Adopters and downstream tools consume the JSON Schema.
+
+Both ship with every OSA release. The release process verifies the JSON Schema is in sync with the YAML before publishing.
+
+## Consequences
+
+- **YAML for humans, JSON Schema for machines.** Each format serves its strongest use case; neither has to compromise.
+- **Tooling owns the YAML-to-JSON-Schema transformation.** Reference tooling ([ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md)) is responsible for this emission and for verifying sync. A drift between the two is a release-blocking bug.
+- **Comments survive in YAML.** Inline rationale and field-level explanations live in the source, where they're preserved and reviewed. JSON Schema's lack of comments doesn't matter — the source carries the commentary.
+- **Language bindings derive from JSON Schema.** Future TypeScript types, Python pydantic models, Go structs, etc. are generated from the JSON Schema, not the YAML, so they pick up the strict typing.
+- **One canonical version pair per release.** `osa-1.0.yaml` + `osa-1.0.schema.json` ship together; downstream tools can pin to either or both.
+- **YAML quirks become content concerns.** Numeric strings, indentation sensitivity, anchor reuse — the schema must be authored defensively to avoid YAML footguns (e.g., quote layer IDs like `"O1"` to prevent boolean coercion).
+
+## Alternatives considered
+
+1. **JSON Schema as the source format.** Verbose for humans, no comments, awkward to author by hand. Rejected — strict typing without authoring ergonomics is the wrong trade for a source-of-truth artifact.
+
+2. **TOML as source.** Cleaner than YAML for flat structures, but OSA's nested layer/relationship structure pulls toward YAML's idioms. TOML's lack of native list-of-objects support adds friction. Rejected for ergonomics.
+
+3. **Protobuf as source.** Strong typing, code generation, mature tooling. Rejected — high barrier for EA/research audience that doesn't already work in Protobuf; less common than YAML; build-tool dependency for editing.
+
+4. **XML Schema (XSD).** Most rigorous, native to the ArchiMate Exchange format. Rejected — XSD authoring is hostile to humans, and the construct schema operates above the ArchiMate level (which is one of several renderings, per ADR-OSA-0001).
+
+5. **Custom DSL.** Premature. YAML already does what's needed; a custom DSL adds a parser, a grammar, and a learning curve for zero immediate gain.
+
+6. **YAML only, no JSON Schema emission.** Loses machine validation in non-YAML-aware tooling. Rejected — half-measure.
+
+## References
+
+- [ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md) — schema-first canonical form (the precondition for this choice)
+- [ADR-OSA-0003](ADR-OSA-0003-construct-vs-deployment-schemas.md) — schema shape (defines what the YAML contains)
+- [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md) — tooling that emits JSON Schema from YAML
+- [JSON Schema specification](https://json-schema.org/)
+- [YAML 1.2.2 specification](https://yaml.org/spec/1.2.2/)

--- a/decisions/ADR-OSA-0003-construct-vs-deployment-schemas.md
+++ b/decisions/ADR-OSA-0003-construct-vs-deployment-schemas.md
@@ -1,0 +1,71 @@
+# ADR-OSA-0003 — Construct schema vs deployment schema (two shapes)
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Author:** JD Longmire
+- **Bundle:** Founding ADR (0003 of 0005)
+
+## Context
+
+The canonical schema (per [ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md), in YAML per [ADR-OSA-0002](ADR-OSA-0002-schema-language-yaml-json-schema.md)) must serve two distinct purposes:
+
+- **Define the OSA construct itself** — the seven layers, the governance principle, allowed authority relationships, the five execution rights, the conformance assertion structure.
+- **Describe a specific deployment claiming conformance** — what tools, agents, and orchestrators populate which layers in a given organization's AI architecture.
+
+These are fundamentally different shapes:
+
+| | Construct | Deployment |
+|---|---|---|
+| Mutability | Immutable within a version | Mutable per org |
+| Authority | Maintainers (via ADR) | Deployment owner |
+| Versioning | OSA release cadence | Local lifecycle |
+| Validation role | The thing validated *against* | The thing *being* validated |
+
+Conflating them — using one schema file for both — makes versioning ambiguous and obscures which fields are construct-level invariants versus per-deployment specifics.
+
+## Decision
+
+**Two distinct schema files per OSA version, with different shapes and lifecycles:**
+
+1. **Construct schema** — `osa-N.M.yaml`
+   - **What it is:** The OSA construct definition itself. Authoritative source for the seven layers, the governance principle, allowed cross-layer relationships, the five execution rights, the conformance assertion vocabulary.
+   - **Mutability:** **Immutable within a version.** Changes flow through ADRs; new constructs ship as new versions (`osa-1.1.yaml`, `osa-2.0.yaml`).
+   - **Authorship:** OSA maintainers, via the ADR + PR process.
+   - **Lifecycle:** Tagged to OSA releases.
+
+2. **Deployment schema** — `<deployment>.yaml` (filename is per-org)
+   - **What it is:** A specific organization's claim of OSA conformance. Lists the deployment's concrete artifacts per layer, makes the conformance assertions defined by the construct, points at evidence.
+   - **Mutability:** Mutable as the deployment evolves. Per-org governance.
+   - **Authorship:** The deployment owner (whatever person, team, or automated process the org delegates to).
+   - **Lifecycle:** Tied to the deployment's life, not OSA's release cadence.
+   - **Validation:** Validated *against* a specific construct version it claims (`osa_construct: "1.0"` in the deployment file points at `osa-1.0.yaml`).
+
+The construct schema is what adopters cite. The deployment schema is what they publish to claim conformance.
+
+## Consequences
+
+- **Versioning is unambiguous.** "What version of OSA does deployment X claim?" has a single answer in the deployment file. "Is this deployment conformant?" reduces to "does deployment X validate against construct version Y?"
+- **Construct-level evolution is governed; deployment-level evolution is not.** Per-org changes don't need ADRs. Construct changes do.
+- **Conformance checking is mechanical.** A validator (per [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md)) takes a deployment file and a construct file, runs schema validation plus the construct-defined conformance rules, and emits pass/fail with reasons.
+- **Multi-version coexistence works.** An org can have multiple deployments at different OSA construct versions; an OSA release can support older deployment files until explicitly deprecated.
+- **The deployment schema's *fields* are defined by the construct schema.** A deployment can't invent new layer IDs or new execution rights — those come from the construct it claims. This is the schema-level enforcement of "no lower layer expands its own authority" (transposed: no deployment expands OSA's own vocabulary).
+- **Per-version migration may become a thing.** Going from a deployment-at-1.0 to deployment-at-1.1 may require field-level updates. Migration helpers are a v0.3+ concern.
+
+## Alternatives considered
+
+1. **Single schema for both.** Conflates immutable construct definition with mutable deployment instance. Versioning becomes ambiguous ("what does it mean for `osa-1.0.yaml` to have my company's specific tools listed?"). Rejected.
+
+2. **Construct as schema, deployment as freeform prose.** Loses mechanical conformance checking — the whole point of having a schema. Rejected.
+
+3. **Deployment as schema, construct as prose.** What v0.1 effectively was. Adopters had nothing to validate against. Rejected.
+
+4. **Three schemas — construct, profile, deployment.** A "profile" intermediate layer for industry- or sector-specific specializations (e.g., "OSA for defense," "OSA for fintech"). Considered but deferred — profiles can be added later as a v0.2+ ADR without breaking the two-schema model. Premature.
+
+5. **Embed deployment as a section inside the construct YAML.** Same conflation problem as alternative 1. Rejected.
+
+## References
+
+- [ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md) — schema-first canonical form
+- [ADR-OSA-0002](ADR-OSA-0002-schema-language-yaml-json-schema.md) — YAML + JSON Schema
+- [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md) — reference validator/generator tooling
+- [`../docs/reference-implementations.md`](../docs/reference-implementations.md) — conformance bar this schema mechanizes

--- a/decisions/ADR-OSA-0004-reference-tooling-python-pydantic.md
+++ b/decisions/ADR-OSA-0004-reference-tooling-python-pydantic.md
@@ -1,0 +1,63 @@
+# ADR-OSA-0004 — Reference tooling: Python + pydantic for v0.2
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Author:** JD Longmire
+- **Bundle:** Founding ADR (0004 of 0005)
+
+## Context
+
+[ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md) through [ADR-OSA-0003](ADR-OSA-0003-construct-vs-deployment-schemas.md) define **what** the canonical OSA artifact is (schema-first, YAML source + JSON Schema, construct schema vs deployment schema). This ADR picks the language and library stack for the **reference tooling** that operates on those artifacts.
+
+The reference tooling has four responsibilities:
+
+1. **Validate** a deployment YAML against a construct YAML — schema validation plus the construct-defined conformance rules.
+2. **Emit** JSON Schema from the YAML construct source (per ADR-OSA-0002).
+3. **Generate** renderings from the canonical schema — first target is ArchiMate (the specific rendering mechanism is [ADR-OSA-0005](ADR-OSA-0005-archi-as-canonical-modeling-tool.md)'s concern), with SysML v2 and other renderings as v0.3+ work.
+4. **Provide a CLI** adopters can run locally or in CI to check conformance and produce renderings.
+
+Language candidates evaluated: **Python**, **Go**, **Rust** (with bindings), **TypeScript**.
+
+## Decision
+
+**Python + pydantic for v0.2 reference tooling.**
+
+- **pydantic** models define the schema in typed Python; emit JSON Schema via `Model.model_json_schema()`; validate YAML/JSON against the models.
+- **pyyaml** (or `ruamel.yaml` if round-trip preservation matters) for YAML loading.
+- **lxml** for any XML manipulation (ArchiMate Open Exchange XML emission/parsing).
+- **click** or **typer** for the CLI surface.
+- Code lives under `tools/osa-validator/` (path subject to refinement). Licensed **Apache-2.0** when the first code lands; the repository's `LICENSE` will be updated at that point to call out the dual-license posture (CC-BY-4.0 for docs + Apache-2.0 for code).
+
+The reference tooling is **a reference**, not a monopoly. Other-language implementations (Go, Rust, TypeScript) are welcome and explicitly anticipated — the canonical artifact is the schema, not the validator.
+
+## Consequences
+
+- **Adopter accessibility.** Python is widely read by EA and research audiences; many adopters will modify the tooling rather than treat it as a black box.
+- **Ecosystem fit for downstream targets.** SysML v2 Pilot Implementation has Python bindings/Jupyter examples; ArchiMate XML manipulation has `lxml` and `pyArchimate`; UAF tooling reachable via Cameo's Python API. Python sits at the intersection of the three downstream worlds.
+- **Distribution via pip.** Not as clean as a single static binary, but standard for the audience. CI integration via `pipx install osa-validator` is straightforward.
+- **The schema is language-neutral; this ADR is replaceable.** A future ADR may add Go or Rust implementations alongside Python without invalidating the schema. The CLI contract becomes the cross-implementation specification.
+- **License split is documented at first-code time.** The README and LICENSE updates ship with the first reference-tooling PR, not now.
+- **Type-safety via pydantic.** pydantic v2's strict mode plus mypy gives strong correctness guarantees. The schema models become the executable specification of the construct.
+- **JSON Schema emission is "free" via pydantic.** `Model.model_json_schema()` produces a draft-2020-12 JSON Schema; no separate transformation tooling needed.
+- **Rendering integrations are subprocess-only.** External rendering libraries with restrictive licenses (notably pyArchimate, GPL-3.0, per [ADR-OSA-0005](ADR-OSA-0005-archi-as-canonical-modeling-tool.md)) are invoked as build-time CLI subprocesses, never imported. This preserves the Apache-2.0 license boundary for distributed code. Reviewers and contributors must enforce this boundary.
+
+## Alternatives considered
+
+1. **Go.** Single static binary is genuinely attractive for CI/admission-controller use cases. Rejected for v0.2 because (a) ArchiMate XML manipulation is more verbose than `lxml`; (b) SysML v2 Python tooling has no Go equivalent; (c) audience reads less Go than Python. A future ADR could add a Go binary as a *distribution mechanism* for the same schema, validated against the Python reference.
+
+2. **Rust core + Python/Go bindings (`pyo3`, `cgo`).** Pattern proven by `ruff`, `polars`, `pydantic-core`. Premature for v0.2 — performance is not load-bearing at construct-schema scale, and the operational complexity of maintaining bindings exceeds the benefit until the validator is in production CI for large orgs.
+
+3. **TypeScript / Node.** Reasonable cross-platform story; weaker ecosystem fit for ArchiMate/SysML v2 downstream targets. Rejected for ecosystem-fit reasons, not language-quality reasons.
+
+4. **No reference tooling (schemas only).** Leaves adopters to write their own validators. Predictable result: per-org reinvention, inconsistent conformance interpretation, no shared CLI. Rejected.
+
+5. **Pure JSON Schema + off-the-shelf validators (no custom code).** Works for schema-shape validation but cannot express construct-defined conformance rules (e.g., "no Assignment relationship from a higher OSA layer ID to a lower one"). Custom logic is required; might as well wrap it in a reference CLI.
+
+## References
+
+- [ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md) — schema-first canonical form
+- [ADR-OSA-0002](ADR-OSA-0002-schema-language-yaml-json-schema.md) — YAML + JSON Schema
+- [ADR-OSA-0003](ADR-OSA-0003-construct-vs-deployment-schemas.md) — construct vs deployment schema shapes
+- [ADR-OSA-0005](ADR-OSA-0005-archi-as-canonical-modeling-tool.md) — ArchiMate rendering pipeline (defines how this tooling generates ArchiMate)
+- [pydantic v2 documentation](https://docs.pydantic.dev/latest/)
+- [JSON Schema 2020-12 (the dialect pydantic emits)](https://json-schema.org/specification.html)

--- a/decisions/ADR-OSA-0005-archi-as-canonical-modeling-tool.md
+++ b/decisions/ADR-OSA-0005-archi-as-canonical-modeling-tool.md
@@ -1,0 +1,78 @@
+# ADR-OSA-0005 — ArchiMate as canonical visual notation; pyArchimate as reference renderer
+
+- **Status:** Accepted
+- **Date:** 2026-05-16
+- **Author:** JD Longmire
+- **Bundle:** Founding ADR (0005 of 0005)
+
+## Context
+
+OSA needs a canonical visual notation for layer diagrams, layer-coverage matrices, conformance examples, and adoption-story figures. Per [ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md), the schema is the source of truth and visual renderings are derived from it. Per [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md), reference tooling is Python.
+
+The choice of visual notation locks two things: (a) which enterprise-architecture audiences see OSA in "their" language, and (b) what tooling sits in the rendering pipeline. Naively, the answer would be "use Archi-the-desktop-tool with ArchiMate-the-language." Research surfaced two facts that change that picture:
+
+1. **Archi's CLI does not export views to SVG/PNG.** A long-standing open feature request ([archimatetool/archi#398](https://github.com/archimatetool/archi/issues/398), #756, #769). The desktop tool exports images via UI; headless CI cannot. This breaks any pipeline that wants to generate diagrams from the schema as part of a build.
+
+2. **pyArchimate v1.9.1** (released 2026-05-14) implements both the full ArchiMate Open Exchange XML object model AND native SVG export via `View.to_svg()` with auto-layout — pure Python, no Java runtime required. License: **GPL-3.0-only**, which matters for how we use it.
+
+Combined: the schema-first principle (ADR-OSA-0001) is best served by *generating diagrams from the schema at build time*, not by hand-editing them in a GUI. pyArchimate enables that. Archi-the-desktop-tool becomes an optional consumer of our artifacts, not a producer in the pipeline.
+
+## Decision
+
+**ArchiMate 3.2 is the canonical visual notation for OSA renderings.** Diagrams in the repo are produced by build-time tooling from the canonical YAML schema, not authored by hand in a GUI.
+
+**The reference rendering pipeline:**
+
+1. **YAML construct/deployment schema** (per ADR-OSA-0001/0002/0003) is the source.
+2. Reference Python tooling (per ADR-OSA-0004) loads the schema and constructs a **pyArchimate** object model.
+3. pyArchimate emits two artifacts:
+   - **ArchiMate Open Exchange XML** — the cross-tool portability artifact. Consumable by Archi, Sparx EA, Cameo, Visual Paradigm, etc. UAF adopters import via Cameo's UAF 1.2 Plugin (lossy but standard).
+   - **SVG** — via `View.to_svg()` with auto-layout. PNG and PDF are post-processed from the SVG via `cairosvg` (Apache-2.0-equivalent license).
+4. Generated artifacts land under `docs/diagrams/` (or similar — finalized in the v0.2 schema PR) and are regenerated as part of the build, not hand-edited.
+
+**License posture.** pyArchimate is GPL-3.0-only. The reference tooling invokes pyArchimate **as a build-time CLI subprocess**, not as an imported library — the standard "GCC posture": using a GPL tool to produce artifacts does not impose GPL on the artifacts or on the calling code. OSA's distributed Python code remains Apache-2.0 (per [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md)). This boundary must be respected: importing pyArchimate as a library would create a license conflict.
+
+**Documented fallback.** If the GPL-via-subprocess posture becomes untenable (legal pushback, pyArchimate stewardship change, or a need to import-link), the swap-in is **Archimate-PlantUML via Kroki HTTP**: MIT-licensed PlantUML macros covering Business/Application/Technology/Motivation/Strategy/Implementation layers, rendered via a Kroki server (no Java in the repo, no JAR dependency). Rendering fidelity is lower than pyArchimate's native output but preserves ArchiMate notation. This fallback is documented but not implemented in v0.2.
+
+**Archi-the-desktop-tool is OPTIONAL** for OSA contributors and consumers. Users who prefer GUI editing/exploration of an ArchiMate model can open the Open Exchange XML we emit. They are not in the build pipeline.
+
+## Consequences
+
+- **Contributors do not need any GUI tool installed.** Schema edits, ADR drafts, rendering changes — all happen in a text editor. CI regenerates diagrams.
+- **Diagrams are reproducible.** The same schema produces the same SVG (modulo auto-layout determinism, which pyArchimate is generally good at). Diff-friendly in PRs because the source is the schema, not the SVG.
+- **No GUI tool is load-bearing.** If Archi's stewardship lapses, OSA's pipeline keeps working; if pyArchimate's GPL posture changes, the Archimate-PlantUML+Kroki fallback exists.
+- **The schema becomes the only thing PRs touch for visual changes.** "Edit the diagram" is "edit the schema, then re-render." No hand-tweaking SVG coordinates in commits.
+- **Cross-tool portability is preserved** via the Open Exchange XML output. UAF, Sparx, Cameo, Visual Paradigm users all consume the same artifact.
+- **pyArchimate auto-layout quality on dense OSA graphs is unverified.** Pilot during the v0.2 schema PR — if layout degrades badly for the seven-layer stack, the fallback may need to come forward.
+- **License documentation is mandatory.** The first PR that introduces pyArchimate as a dependency must include a clear `tools/README.md` note explaining the subprocess-only usage and the Apache-2.0 boundary. Future contributors must not casually `import pyarchimate` from distributed code.
+- **ArchiMate 3.2, not 4.** pyArchimate currently targets 3.2; ArchiMate 4 (released April 2026) is not yet covered by the broader Open Source ArchiMate ecosystem (Archi itself doesn't support 4 either). Migration is a 2026-Q4 or 2027 watch item, not an immediate concern.
+
+## Alternatives considered
+
+1. **Archi-the-desktop-tool as the canonical rendering tool.** What "Archi as tool of choice" originally meant. Rejected after research surfaced that Archi's CLI can't export SVG/PNG — this would force hand-rendering and break the schema-first principle. Archi remains useful as a *consumer* of our XML artifacts.
+
+2. **Archi headless image export.** Would solve the rendering pipeline if it existed. It doesn't — the feature has been open since 2018. Rejected as not real.
+
+3. **pyArchimate imported as a library (not subprocess).** Cleanest from a code-architecture perspective. Rejected — GPL-3.0 would impose GPL on the importing code, conflicting with [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md)'s Apache-2.0 choice. The subprocess boundary preserves both.
+
+4. **Archimate-PlantUML via Kroki as primary.** Apache-friendly license, no GPL concerns. Rejected as primary because rendering fidelity is lower than pyArchimate's native output, and Kroki adds an HTTP dependency that complicates offline build environments. Retained as documented fallback.
+
+5. **Graphviz / Mermaid / D2 as primary visual.** All produce SVG/PNG/PDF natively from pure Python with permissive licenses. Rejected — none of them produce ArchiMate-shaped notation, which means adopters in EA tooling can't recognize the construct in "their" language. Loses the cross-audience portability that motivated picking ArchiMate at all.
+
+6. **Sparx EA, Cameo, IBM Rhapsody as canonical tool.** Strong triad coverage (UAF + SysML v2 + ArchiMate). Rejected for v0.2 — commercial licenses incompatible with unaffiliated-research budget posture. Revisit if/when commercial sponsorship enters the picture.
+
+7. **No designated rendering pipeline.** Adopters render diagrams themselves in whatever tool they prefer. Rejected — without canonical diagrams in the repo, the prose is the only OSA artifact most readers will see. Visualizable OSA matters for adoption.
+
+## References
+
+- [ADR-OSA-0001](ADR-OSA-0001-schema-first-canonical-form.md) — schema-first canonical form (the principle this ADR operationalizes for visuals)
+- [ADR-OSA-0002](ADR-OSA-0002-schema-language-yaml-json-schema.md) — YAML + JSON Schema (the input to the rendering pipeline)
+- [ADR-OSA-0004](ADR-OSA-0004-reference-tooling-python-pydantic.md) — Python + pydantic reference tooling (the host of the subprocess invocation)
+- [pyArchimate on PyPI](https://pypi.org/project/pyArchimate/) — the reference renderer
+- [pyArchimate on GitHub](https://github.com/pyArchimate/pyArchimate)
+- [Archi CLI wiki (no SVG export)](https://github.com/archimatetool/archi/wiki/Archi-Command-Line-Interface)
+- [Archi issue #398 — long-standing SVG export request](https://github.com/archimatetool/archi/issues/398)
+- [Archimate-PlantUML — documented fallback](https://github.com/plantuml-stdlib/Archimate-PlantUML)
+- [Kroki — fallback renderer host](https://kroki.io/)
+- [ArchiMate 3.2 specification](https://pubs.opengroup.org/architecture/archimate3-doc/)
+- [`../docs/relationship-to-frameworks.md`](../docs/relationship-to-frameworks.md) — ArchiMate's role relative to TOGAF/UAF/NIST AI RMF

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -8,7 +8,15 @@ For the authoring process, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For t
 
 | ADR | Status | Date | Title |
 |---|---|---|---|
-| _none yet_ | — | — | The founding ADRs (0001–0004) will land with the v0.2 schema PR. |
+| [0001](ADR-OSA-0001-schema-first-canonical-form.md) | Accepted | 2026-05-16 | Schema-first canonical form |
+| [0002](ADR-OSA-0002-schema-language-yaml-json-schema.md) | Accepted | 2026-05-16 | Schema language: YAML source + auto-emitted JSON Schema |
+| [0003](ADR-OSA-0003-construct-vs-deployment-schemas.md) | Accepted | 2026-05-16 | Construct schema vs deployment schema (two shapes) |
+| [0004](ADR-OSA-0004-reference-tooling-python-pydantic.md) | Accepted | 2026-05-16 | Reference tooling: Python + pydantic for v0.2 |
+| [0005](ADR-OSA-0005-archi-as-canonical-modeling-tool.md) | Accepted | 2026-05-16 | ArchiMate as canonical visual notation; pyArchimate as reference renderer |
+
+### Founding bundle
+
+ADRs 0001–0005 ratify the v0.2 baseline as a single coherent set: schema-first source of truth (0001), YAML + JSON Schema (0002), construct vs deployment shapes (0003), Python + pydantic for reference tooling (0004), and ArchiMate via pyArchimate for visual rendering (0005). Per [`../CONTRIBUTING.md`](../CONTRIBUTING.md), founding ADRs are exempt from the one-week comment-out period; future ADRs follow the standard cadence.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Five founding ADRs land as a single bundle, ratifying the v0.2 baseline:

| ADR | Decision |
|---|---|
| [0001](../blob/dev/decisions/ADR-OSA-0001-schema-first-canonical-form.md) | Schema-first canonical form — schema is source of truth; renderings are derived |
| [0002](../blob/dev/decisions/ADR-OSA-0002-schema-language-yaml-json-schema.md) | YAML source + auto-emitted JSON Schema per release |
| [0003](../blob/dev/decisions/ADR-OSA-0003-construct-vs-deployment-schemas.md) | Two schema shapes: \`osa-N.M.yaml\` (construct, immutable) + \`<deployment>.yaml\` (mutable, per-org) |
| [0004](../blob/dev/decisions/ADR-OSA-0004-reference-tooling-python-pydantic.md) | Python + pydantic for v0.2 reference tooling (Apache-2.0 when code lands) |
| [0005](../blob/dev/decisions/ADR-OSA-0005-archi-as-canonical-modeling-tool.md) | ArchiMate as visual notation, pyArchimate as renderer (subprocess; preserves Apache-2.0 boundary against GPL-3.0) |

Bundling rationale: the five decisions are interlocking — 0001 sets the principle, 0002–0003 pick the format, 0004 picks the tooling that operates on it, 0005 picks the rendering pipeline. Splitting them into five PRs would create review churn around cross-references that don't resolve until the bundle is complete. Founding bundles are explicitly carved out from the one-week comment-out period in [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md).

## Traceability + knowledge management touch-ups

- **\`decisions/README.md\`** — populated index table; added a "Founding bundle" callout
- **Main \`README.md\`**:
  - Added **Governance** section pointing at the ADR index with one-line summaries of each founding ADR
  - Updated **Status** section to reflect v0.1.x → v0.2 transition
  - Tightened **Contributing** section to call out PR-first ADR flow with \`adr\` label and Construct Q&A discussion
  - Added \`decisions/README.md\` to the "Read the Construct" nav

## Touch-up to ADR-0004

ADR-OSA-0004 gains one Consequence bullet noting the subprocess-only posture for GPL-licensed rendering dependencies (paired with 0005's pyArchimate choice). This makes the license boundary explicit in the tooling ADR rather than only in the rendering ADR.

## What's NOT in this PR

- **v0.2 schema sketch** (\`docs/schema/osa-1.0.yaml\`, example deployment, schema README) — lands as the next PR, embodying these ADRs
- **Reference tooling implementation** — follow-on PR after the schema sketch is reviewed
- **First diagrams via pyArchimate** — proves out the auto-layout question raised in 0005's uncertainty flags

## QA

Pass with 2 non-blocking warnings — both flag future work already documented in the ADRs themselves (pyArchimate auto-layout pilot; LICENSE update at first-code PR). \`qa_log\` entry: \`2026-05-16T15:11Z\`.

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] All cross-references between ADRs resolve
- [x] decisions/README.md index matches the actual ADR files in the directory
- [x] Main README.md Governance section links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)